### PR TITLE
Add support for count-based occurrence constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reprise"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/docs/Reprise.html
+++ b/docs/Reprise.html
@@ -109,7 +109,7 @@
         <dt id="VERSION-constant" class="">VERSION =
           
         </dt>
-        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>0.1.1</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>0.1.2</span><span class='tstring_end'>&quot;</span></span></pre></dd>
       
     </dl>
   
@@ -125,7 +125,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:56 2024 by
+  Generated on Sun Jul 21 10:23:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/Core.html
+++ b/docs/Reprise/Core.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:56 2024 by
+  Generated on Sun Jul 21 10:23:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/Core/Occurrence.html
+++ b/docs/Reprise/Core/Occurrence.html
@@ -392,7 +392,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:57 2024 by
+  Generated on Sun Jul 21 10:23:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/Error.html
+++ b/docs/Reprise/Error.html
@@ -118,7 +118,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:56 2024 by
+  Generated on Sun Jul 21 10:23:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/InvalidTimeZoneError.html
+++ b/docs/Reprise/InvalidTimeZoneError.html
@@ -122,7 +122,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:57 2024 by
+  Generated on Sun Jul 21 10:23:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/Schedule.html
+++ b/docs/Reprise/Schedule.html
@@ -287,7 +287,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#repeat_annually_by_day-instance_method" title="#repeat_annually_by_day (instance method)">#<strong>repeat_annually_by_day</strong>(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; void </a>
+      <a href="#repeat_annually_by_day-instance_method" title="#repeat_annually_by_day (instance method)">#<strong>repeat_annually_by_day</strong>(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; void </a>
     
 
     
@@ -309,7 +309,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#repeat_daily-instance_method" title="#repeat_daily (instance method)">#<strong>repeat_daily</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; void </a>
+      <a href="#repeat_daily-instance_method" title="#repeat_daily (instance method)">#<strong>repeat_daily</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; void </a>
     
 
     
@@ -331,7 +331,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#repeat_hourly-instance_method" title="#repeat_hourly (instance method)">#<strong>repeat_hourly</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; void </a>
+      <a href="#repeat_hourly-instance_method" title="#repeat_hourly (instance method)">#<strong>repeat_hourly</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; void </a>
     
 
     
@@ -353,7 +353,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#repeat_minutely-instance_method" title="#repeat_minutely (instance method)">#<strong>repeat_minutely</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; void </a>
+      <a href="#repeat_minutely-instance_method" title="#repeat_minutely (instance method)">#<strong>repeat_minutely</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; void </a>
     
 
     
@@ -375,7 +375,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#repeat_monthly_by_day-instance_method" title="#repeat_monthly_by_day (instance method)">#<strong>repeat_monthly_by_day</strong>(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; void </a>
+      <a href="#repeat_monthly_by_day-instance_method" title="#repeat_monthly_by_day (instance method)">#<strong>repeat_monthly_by_day</strong>(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; void </a>
     
 
     
@@ -397,7 +397,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#repeat_monthly_by_nth_weekday-instance_method" title="#repeat_monthly_by_nth_weekday (instance method)">#<strong>repeat_monthly_by_nth_weekday</strong>(weekday, nth_day, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; void </a>
+      <a href="#repeat_monthly_by_nth_weekday-instance_method" title="#repeat_monthly_by_nth_weekday (instance method)">#<strong>repeat_monthly_by_nth_weekday</strong>(weekday, nth_day, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; void </a>
     
 
     
@@ -419,7 +419,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#repeat_weekly-instance_method" title="#repeat_weekly (instance method)">#<strong>repeat_weekly</strong>(weekday, time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; void </a>
+      <a href="#repeat_weekly-instance_method" title="#repeat_weekly (instance method)">#<strong>repeat_weekly</strong>(weekday, time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; void </a>
     
 
     
@@ -636,15 +636,15 @@
       <pre class="lines">
 
 
-234
-235
-236
-237
-238
-239</pre>
+254
+255
+256
+257
+258
+259</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 234</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 254</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_add_exclusion'>add_exclusion</span><span class='lparen'>(</span><span class='label'>starts_at:</span><span class='comma'>,</span> <span class='label'>ends_at:</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_add_exclusion'>add_exclusion</span><span class='lparen'>(</span>
@@ -714,14 +714,14 @@
       <pre class="lines">
 
 
-251
-252
-253
-254
-255</pre>
+271
+272
+273
+274
+275</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 251</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 271</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_add_exclusions'>add_exclusions</span><span class='lparen'>(</span><span class='id identifier rubyid_exclusions'>exclusions</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_add_exclusions'>add_exclusions</span><span class='lparen'>(</span>
@@ -885,16 +885,16 @@
       <pre class="lines">
 
 
-277
-278
-279
-280
-281
-282
-283</pre>
+297
+298
+299
+300
+301
+302
+303</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 277</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 297</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_occurrences_between'>occurrences_between</span><span class='lparen'>(</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='comma'>,</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='comma'>,</span> <span class='label'>include_overlapping:</span> <span class='kw'>false</span><span class='rparen'>)</span>
   <span class='kw'>if</span> <span class='id identifier rubyid_include_overlapping'>include_overlapping</span>
@@ -1001,12 +1001,12 @@
       <pre class="lines">
 
 
-267
-268
-269</pre>
+287
+288
+289</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 267</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 287</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_occurs_between?'>occurs_between?</span><span class='lparen'>(</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='comma'>,</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='comma'>,</span> <span class='label'>include_overlapping:</span> <span class='kw'>false</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_occurrences_between'>occurrences_between</span><span class='lparen'>(</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='comma'>,</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='comma'>,</span> <span class='label'>include_overlapping:</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_any?'>any?</span>
@@ -1019,7 +1019,7 @@
       <div class="method_details ">
   <h3 class="signature " id="repeat_annually_by_day-instance_method">
   
-    #<strong>repeat_annually_by_day</strong>(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; <tt>void</tt> 
+    #<strong>repeat_annually_by_day</strong>(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; <tt>void</tt> 
   
 
   
@@ -1147,6 +1147,24 @@
   
     <li>
       
+        <span class='name'>count</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>, <tt>nil</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>An optional count limit to apply to the occurrences of a series; once the schedule has generated the requested number of occurrences, it will halt further expansion of that specific series. The count takes precedence over the optional <code>ends_at</code> param.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
         <span class='name'>label</span>
       
       
@@ -1224,6 +1242,8 @@
     
     
     
+    
+    
 
 <p class="tag_title">Raises:</p>
 <ul class="raise">
@@ -1278,22 +1298,23 @@
       <pre class="lines">
 
 
-218
-219
-220
-221
-222
-223
-224
-225
-226
-227
-228</pre>
+237
+238
+239
+240
+241
+242
+243
+244
+245
+246
+247
+248</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 218</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 237</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_repeat_annually_by_day'>repeat_annually_by_day</span><span class='lparen'>(</span><span class='id identifier rubyid_day_number'>day_number</span><span class='comma'>,</span> <span class='label'>time_of_day:</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_repeat_annually_by_day'>repeat_annually_by_day</span><span class='lparen'>(</span><span class='id identifier rubyid_day_number'>day_number</span><span class='comma'>,</span> <span class='label'>time_of_day:</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_repeat_annually_by_day'>repeat_annually_by_day</span><span class='lparen'>(</span>
     <span class='id identifier rubyid_day_number'>day_number</span><span class='comma'>,</span>
     <span class='label'>time_of_day:</span> <span class='const'><span class='object_link'><a href="TimeOfDay.html" title="Reprise::TimeOfDay (class)">TimeOfDay</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="TimeOfDay.html#initialize-instance_method" title="Reprise::TimeOfDay#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_time_of_day'>time_of_day</span> <span class='op'>||</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_h'><span class='object_link'><a href="TimeOfDay.html#to_h-instance_method" title="Reprise::TimeOfDay#to_h (method)">to_h</a></span></span><span class='comma'>,</span>
@@ -1301,6 +1322,7 @@
     <span class='label'>interval:</span><span class='comma'>,</span>
     <span class='label'>starts_at_unix_timestamp:</span> <span class='id identifier rubyid_starts_at'>starts_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
     <span class='label'>ends_at_unix_timestamp:</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>count:</span><span class='comma'>,</span>
     <span class='label'>label:</span>
   <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -1312,7 +1334,7 @@
       <div class="method_details ">
   <h3 class="signature " id="repeat_daily-instance_method">
   
-    #<strong>repeat_daily</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; <tt>void</tt> 
+    #<strong>repeat_daily</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; <tt>void</tt> 
   
 
   
@@ -1418,6 +1440,24 @@
   
     <li>
       
+        <span class='name'>count</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>, <tt>nil</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>An optional count limit to apply to the occurrences of a series; once the schedule has generated the requested number of occurrences, it will halt further expansion of that specific series. The count takes precedence over the optional <code>ends_at</code> param.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
         <span class='name'>label</span>
       
       
@@ -1493,6 +1533,8 @@
     
     
     
+    
+    
 
 <p class="tag_title">Raises:</p>
 <ul class="raise">
@@ -1547,27 +1589,29 @@
       <pre class="lines">
 
 
-132
-133
-134
-135
-136
-137
-138
-139
-140
-141</pre>
+143
+144
+145
+146
+147
+148
+149
+150
+151
+152
+153</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 132</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 143</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_repeat_daily'>repeat_daily</span><span class='lparen'>(</span><span class='label'>time_of_day:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_repeat_daily'>repeat_daily</span><span class='lparen'>(</span><span class='label'>time_of_day:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_repeat_daily'>repeat_daily</span><span class='lparen'>(</span>
     <span class='label'>time_of_day:</span> <span class='const'><span class='object_link'><a href="TimeOfDay.html" title="Reprise::TimeOfDay (class)">TimeOfDay</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="TimeOfDay.html#initialize-instance_method" title="Reprise::TimeOfDay#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_time_of_day'>time_of_day</span> <span class='op'>||</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_h'><span class='object_link'><a href="TimeOfDay.html#to_h-instance_method" title="Reprise::TimeOfDay#to_h (method)">to_h</a></span></span><span class='comma'>,</span>
     <span class='label'>duration_in_seconds:</span><span class='comma'>,</span>
     <span class='label'>interval:</span><span class='comma'>,</span>
     <span class='label'>starts_at_unix_timestamp:</span> <span class='id identifier rubyid_starts_at'>starts_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
     <span class='label'>ends_at_unix_timestamp:</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>count:</span><span class='comma'>,</span>
     <span class='label'>label:</span>
   <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -1579,7 +1623,7 @@
       <div class="method_details ">
   <h3 class="signature " id="repeat_hourly-instance_method">
   
-    #<strong>repeat_hourly</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; <tt>void</tt> 
+    #<strong>repeat_hourly</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; <tt>void</tt> 
   
 
   
@@ -1685,6 +1729,24 @@
   
     <li>
       
+        <span class='name'>count</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>, <tt>nil</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>An optional count limit to apply to the occurrences of a series; once the schedule has generated the requested number of occurrences, it will halt further expansion of that specific series. The count takes precedence over the optional <code>ends_at</code> param.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
         <span class='name'>label</span>
       
       
@@ -1760,6 +1822,8 @@
     
     
     
+    
+    
 
 <p class="tag_title">Raises:</p>
 <ul class="raise">
@@ -1814,27 +1878,29 @@
       <pre class="lines">
 
 
-115
-116
-117
-118
-119
-120
-121
-122
-123
-124</pre>
+124
+125
+126
+127
+128
+129
+130
+131
+132
+133
+134</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 115</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 124</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_repeat_hourly'>repeat_hourly</span><span class='lparen'>(</span><span class='label'>time_of_day:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_repeat_hourly'>repeat_hourly</span><span class='lparen'>(</span><span class='label'>time_of_day:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_repeat_hourly'>repeat_hourly</span><span class='lparen'>(</span>
     <span class='label'>time_of_day:</span> <span class='const'><span class='object_link'><a href="TimeOfDay.html" title="Reprise::TimeOfDay (class)">TimeOfDay</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="TimeOfDay.html#initialize-instance_method" title="Reprise::TimeOfDay#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_time_of_day'>time_of_day</span> <span class='op'>||</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_h'><span class='object_link'><a href="TimeOfDay.html#to_h-instance_method" title="Reprise::TimeOfDay#to_h (method)">to_h</a></span></span><span class='comma'>,</span>
     <span class='label'>duration_in_seconds:</span><span class='comma'>,</span>
     <span class='label'>interval:</span><span class='comma'>,</span>
     <span class='label'>starts_at_unix_timestamp:</span> <span class='id identifier rubyid_starts_at'>starts_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
     <span class='label'>ends_at_unix_timestamp:</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>count:</span><span class='comma'>,</span>
     <span class='label'>label:</span>
   <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -1846,7 +1912,7 @@
       <div class="method_details ">
   <h3 class="signature " id="repeat_minutely-instance_method">
   
-    #<strong>repeat_minutely</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; <tt>void</tt> 
+    #<strong>repeat_minutely</strong>(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; <tt>void</tt> 
   
 
   
@@ -1952,6 +2018,24 @@
   
     <li>
       
+        <span class='name'>count</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>, <tt>nil</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>An optional count limit to apply to the occurrences of a series; once the schedule has generated the requested number of occurrences, it will halt further expansion of that specific series. The count takes precedence over the optional <code>ends_at</code> param.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
         <span class='name'>label</span>
       
       
@@ -2027,6 +2111,8 @@
     
     
     
+    
+    
 
 <p class="tag_title">Raises:</p>
 <ul class="raise">
@@ -2081,27 +2167,29 @@
       <pre class="lines">
 
 
-98
-99
-100
-101
-102
-103
-104
 105
 106
-107</pre>
+107
+108
+109
+110
+111
+112
+113
+114
+115</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 98</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 105</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_repeat_minutely'>repeat_minutely</span><span class='lparen'>(</span><span class='label'>time_of_day:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_repeat_minutely'>repeat_minutely</span><span class='lparen'>(</span><span class='label'>time_of_day:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_repeat_minutely'>repeat_minutely</span><span class='lparen'>(</span>
     <span class='label'>time_of_day:</span> <span class='const'><span class='object_link'><a href="TimeOfDay.html" title="Reprise::TimeOfDay (class)">TimeOfDay</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="TimeOfDay.html#initialize-instance_method" title="Reprise::TimeOfDay#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_time_of_day'>time_of_day</span> <span class='op'>||</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_h'><span class='object_link'><a href="TimeOfDay.html#to_h-instance_method" title="Reprise::TimeOfDay#to_h (method)">to_h</a></span></span><span class='comma'>,</span>
     <span class='label'>duration_in_seconds:</span><span class='comma'>,</span>
     <span class='label'>interval:</span><span class='comma'>,</span>
     <span class='label'>starts_at_unix_timestamp:</span> <span class='id identifier rubyid_starts_at'>starts_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
     <span class='label'>ends_at_unix_timestamp:</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>count:</span><span class='comma'>,</span>
     <span class='label'>label:</span>
   <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -2113,7 +2201,7 @@
       <div class="method_details ">
   <h3 class="signature " id="repeat_monthly_by_day-instance_method">
   
-    #<strong>repeat_monthly_by_day</strong>(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; <tt>void</tt> 
+    #<strong>repeat_monthly_by_day</strong>(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; <tt>void</tt> 
   
 
   
@@ -2241,6 +2329,24 @@
   
     <li>
       
+        <span class='name'>count</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>, <tt>nil</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>An optional count limit to apply to the occurrences of a series; once the schedule has generated the requested number of occurrences, it will halt further expansion of that specific series. The count takes precedence over the optional <code>ends_at</code> param.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
         <span class='name'>label</span>
       
       
@@ -2318,6 +2424,8 @@
     
     
     
+    
+    
 
 <p class="tag_title">Raises:</p>
 <ul class="raise">
@@ -2372,22 +2480,23 @@
       <pre class="lines">
 
 
-176
-177
-178
-179
-180
-181
-182
-183
-184
-185
-186</pre>
+191
+192
+193
+194
+195
+196
+197
+198
+199
+200
+201
+202</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 176</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 191</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_repeat_monthly_by_day'>repeat_monthly_by_day</span><span class='lparen'>(</span><span class='id identifier rubyid_day_number'>day_number</span><span class='comma'>,</span> <span class='label'>time_of_day:</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_repeat_monthly_by_day'>repeat_monthly_by_day</span><span class='lparen'>(</span><span class='id identifier rubyid_day_number'>day_number</span><span class='comma'>,</span> <span class='label'>time_of_day:</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_repeat_monthly_by_day'>repeat_monthly_by_day</span><span class='lparen'>(</span>
     <span class='id identifier rubyid_day_number'>day_number</span><span class='comma'>,</span>
     <span class='label'>time_of_day:</span> <span class='const'><span class='object_link'><a href="TimeOfDay.html" title="Reprise::TimeOfDay (class)">TimeOfDay</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="TimeOfDay.html#initialize-instance_method" title="Reprise::TimeOfDay#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_time_of_day'>time_of_day</span> <span class='op'>||</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_h'><span class='object_link'><a href="TimeOfDay.html#to_h-instance_method" title="Reprise::TimeOfDay#to_h (method)">to_h</a></span></span><span class='comma'>,</span>
@@ -2395,6 +2504,7 @@
     <span class='label'>interval:</span><span class='comma'>,</span>
     <span class='label'>starts_at_unix_timestamp:</span> <span class='id identifier rubyid_starts_at'>starts_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
     <span class='label'>ends_at_unix_timestamp:</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>count:</span><span class='comma'>,</span>
     <span class='label'>label:</span>
   <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -2406,7 +2516,7 @@
       <div class="method_details ">
   <h3 class="signature " id="repeat_monthly_by_nth_weekday-instance_method">
   
-    #<strong>repeat_monthly_by_nth_weekday</strong>(weekday, nth_day, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; <tt>void</tt> 
+    #<strong>repeat_monthly_by_nth_weekday</strong>(weekday, nth_day, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; <tt>void</tt> 
   
 
   
@@ -2542,6 +2652,24 @@
   
     <li>
       
+        <span class='name'>count</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>, <tt>nil</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>An optional count limit to apply to the occurrences of a series; once the schedule has generated the requested number of occurrences, it will halt further expansion of that specific series. The count takes precedence over the optional <code>ends_at</code> param.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
         <span class='name'>label</span>
       
       
@@ -2621,6 +2749,8 @@
     
     
     
+    
+    
 
 <p class="tag_title">Raises:</p>
 <ul class="raise">
@@ -2675,23 +2805,24 @@
       <pre class="lines">
 
 
-196
-197
-198
-199
-200
-201
-202
-203
-204
-205
-206
-207</pre>
+213
+214
+215
+216
+217
+218
+219
+220
+221
+222
+223
+224
+225</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 196</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 213</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_repeat_monthly_by_nth_weekday'>repeat_monthly_by_nth_weekday</span><span class='lparen'>(</span><span class='id identifier rubyid_weekday'>weekday</span><span class='comma'>,</span> <span class='id identifier rubyid_nth_day'>nth_day</span><span class='comma'>,</span> <span class='label'>time_of_day:</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_repeat_monthly_by_nth_weekday'>repeat_monthly_by_nth_weekday</span><span class='lparen'>(</span><span class='id identifier rubyid_weekday'>weekday</span><span class='comma'>,</span> <span class='id identifier rubyid_nth_day'>nth_day</span><span class='comma'>,</span> <span class='label'>time_of_day:</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_repeat_monthly_by_nth_weekday'>repeat_monthly_by_nth_weekday</span><span class='lparen'>(</span>
     <span class='id identifier rubyid_weekday'>weekday</span><span class='comma'>,</span>
     <span class='id identifier rubyid_nth_day'>nth_day</span><span class='comma'>,</span>
@@ -2700,6 +2831,7 @@
     <span class='label'>interval:</span><span class='comma'>,</span>
     <span class='label'>starts_at_unix_timestamp:</span> <span class='id identifier rubyid_starts_at'>starts_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
     <span class='label'>ends_at_unix_timestamp:</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>count:</span><span class='comma'>,</span>
     <span class='label'>label:</span>
   <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -2711,7 +2843,7 @@
       <div class="method_details ">
   <h3 class="signature " id="repeat_weekly-instance_method">
   
-    #<strong>repeat_weekly</strong>(weekday, time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)  &#x21d2; <tt>void</tt> 
+    #<strong>repeat_weekly</strong>(weekday, time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)  &#x21d2; <tt>void</tt> 
   
 
   
@@ -2853,6 +2985,24 @@
   
     <li>
       
+        <span class='name'>count</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>, <tt>nil</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>An optional count limit to apply to the occurrences of a series; once the schedule has generated the requested number of occurrences, it will halt further expansion of that specific series. The count takes precedence over the optional <code>ends_at</code> param.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
         <span class='name'>label</span>
       
       
@@ -2930,6 +3080,8 @@
     
     
     
+    
+    
 
 <p class="tag_title">Raises:</p>
 <ul class="raise">
@@ -2984,22 +3136,23 @@
       <pre class="lines">
 
 
-155
-156
-157
-158
-159
-160
-161
-162
-163
-164
-165</pre>
+168
+169
+170
+171
+172
+173
+174
+175
+176
+177
+178
+179</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 155</span>
+      <pre class="code"><span class="info file"># File 'lib/reprise/schedule.rb', line 168</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_repeat_weekly'>repeat_weekly</span><span class='lparen'>(</span><span class='id identifier rubyid_weekday'>weekday</span><span class='comma'>,</span> <span class='label'>time_of_day:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_repeat_weekly'>repeat_weekly</span><span class='lparen'>(</span><span class='id identifier rubyid_weekday'>weekday</span><span class='comma'>,</span> <span class='label'>time_of_day:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>duration_in_seconds:</span><span class='comma'>,</span> <span class='label'>interval:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>starts_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>ends_at:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_internal_schedule'>internal_schedule</span><span class='period'>.</span><span class='id identifier rubyid_repeat_weekly'>repeat_weekly</span><span class='lparen'>(</span>
     <span class='id identifier rubyid_weekday'>weekday</span><span class='comma'>,</span>
     <span class='label'>time_of_day:</span> <span class='const'><span class='object_link'><a href="TimeOfDay.html" title="Reprise::TimeOfDay (class)">TimeOfDay</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="TimeOfDay.html#initialize-instance_method" title="Reprise::TimeOfDay#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_time_of_day'>time_of_day</span> <span class='op'>||</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_starts_at'>starts_at</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_h'><span class='object_link'><a href="TimeOfDay.html#to_h-instance_method" title="Reprise::TimeOfDay#to_h (method)">to_h</a></span></span><span class='comma'>,</span>
@@ -3007,6 +3160,7 @@
     <span class='label'>interval:</span><span class='comma'>,</span>
     <span class='label'>starts_at_unix_timestamp:</span> <span class='id identifier rubyid_starts_at'>starts_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
     <span class='label'>ends_at_unix_timestamp:</span> <span class='id identifier rubyid_ends_at'>ends_at</span><span class='period'>.</span><span class='id identifier rubyid_presence'>presence</span><span class='op'>&amp;.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>count:</span><span class='comma'>,</span>
     <span class='label'>label:</span>
   <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -3020,7 +3174,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:57 2024 by
+  Generated on Sun Jul 21 10:23:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/TimeOfDay.html
+++ b/docs/Reprise/TimeOfDay.html
@@ -495,7 +495,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:57 2024 by
+  Generated on Sun Jul 21 10:23:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/TimeOfDay/InvalidHashError.html
+++ b/docs/Reprise/TimeOfDay/InvalidHashError.html
@@ -135,7 +135,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:57 2024 by
+  Generated on Sun Jul 21 10:23:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/TimeOfDay/RangeError.html
+++ b/docs/Reprise/TimeOfDay/RangeError.html
@@ -135,7 +135,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:57 2024 by
+  Generated on Sun Jul 21 10:23:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/TimeOfDay/UnsupportedTypeError.html
+++ b/docs/Reprise/TimeOfDay/UnsupportedTypeError.html
@@ -135,7 +135,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:57 2024 by
+  Generated on Sun Jul 21 10:23:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/Reprise/TimeZoneIdentifier.html
+++ b/docs/Reprise/TimeZoneIdentifier.html
@@ -402,7 +402,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:57 2024 by
+  Generated on Sun Jul 21 10:23:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -233,7 +233,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:56 2024 by
+  Generated on Sun Jul 21 10:23:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -277,7 +277,7 @@ you would probably be much better served by choosing one of those two gems inste
 the influence of Rust leaks into its Ruby API. Alternative gems offer much more flexible APIs that support a variety
 of more idiomatic calling conventions: they have better, more forgiving ergonomics. Reprise may invest more efforts
 here in the future, but not until we have landed on a feature-complete, performant core - our primary design goal. 
-Until then, out API will remain sparse but sufficient.</li>
+Until then, our API will remain sparse but sufficient.</li>
 <li><strong>Stability.</strong> Reprise is still experimental; we do not yet have a <code>1.0.0</code> release or a public roadmap. Breaking changes
 may be frequent across releases. If you do not want to pin Reprise to a specific version and want a library that you can
 upgrade without reviewing the changelog, you may want to consider an alternative for now.</li>
@@ -391,8 +391,6 @@ in your application?</p>
 <p>At time of writing, alternative gems&#39; solutions to this problem are somewhat wanting:</p>
 
 <ul>
-<li><strong>None</strong>: It is entirely the responsibility of the client application to handle occurrence exclusions,
-despite this logic being core to the domain of recurring schedule management.</li>
 <li><strong>Date-based exclusion</strong>: Client applications can pass specific dates when occurrences should be excluded.
 This is not sufficient except for in the most simple of circumstances. Again, consider our hypothetical
 Monday @ 12:30 PM recurring series: being able to exclude a specific <em>date</em> from your recurrence rule still 
@@ -450,7 +448,7 @@ once we&#39;ve hit that milestone.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:56 2024 by
+  Generated on Sun Jul 21 10:23:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -277,7 +277,7 @@ you would probably be much better served by choosing one of those two gems inste
 the influence of Rust leaks into its Ruby API. Alternative gems offer much more flexible APIs that support a variety
 of more idiomatic calling conventions: they have better, more forgiving ergonomics. Reprise may invest more efforts
 here in the future, but not until we have landed on a feature-complete, performant core - our primary design goal. 
-Until then, out API will remain sparse but sufficient.</li>
+Until then, our API will remain sparse but sufficient.</li>
 <li><strong>Stability.</strong> Reprise is still experimental; we do not yet have a <code>1.0.0</code> release or a public roadmap. Breaking changes
 may be frequent across releases. If you do not want to pin Reprise to a specific version and want a library that you can
 upgrade without reviewing the changelog, you may want to consider an alternative for now.</li>
@@ -391,8 +391,6 @@ in your application?</p>
 <p>At time of writing, alternative gems&#39; solutions to this problem are somewhat wanting:</p>
 
 <ul>
-<li><strong>None</strong>: It is entirely the responsibility of the client application to handle occurrence exclusions,
-despite this logic being core to the domain of recurring schedule management.</li>
 <li><strong>Date-based exclusion</strong>: Client applications can pass specific dates when occurrences should be excluded.
 This is not sufficient except for in the most simple of circumstances. Again, consider our hypothetical
 Monday @ 12:30 PM recurring series: being able to exclude a specific <em>date</em> from your recurrence rule still 
@@ -450,7 +448,7 @@ once we&#39;ve hit that milestone.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:56 2024 by
+  Generated on Sun Jul 21 10:23:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jul 20 19:34:56 2024 by
+  Generated on Sun Jul 21 10:23:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.3.2).
 </div>

--- a/ext/reprise/Cargo.toml
+++ b/ext/reprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reprise"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 build = "build.rs"

--- a/ext/reprise/src/ruby_api/series_options.rs
+++ b/ext/reprise/src/ruby_api/series_options.rs
@@ -15,6 +15,7 @@ pub(crate) struct SeriesOptions {
     // parent schedule itself.
     pub(crate) starts_at_unix_timestamp: Option<UnixTimestamp>,
     pub(crate) ends_at_unix_timestamp: Option<UnixTimestamp>,
+    pub(crate) count: Option<u64>,
     pub(crate) label: Option<String>,
 }
 
@@ -24,6 +25,7 @@ type RubySeriesOptionsKwargs = (
     i64,
     Option<UnixTimestamp>,
     Option<UnixTimestamp>,
+    Option<u64>,
     Option<String>,
 );
 
@@ -37,6 +39,7 @@ impl SeriesOptions {
                 "interval",
                 "starts_at_unix_timestamp",
                 "ends_at_unix_timestamp",
+                "count",
                 "label",
             ],
             &[],
@@ -48,6 +51,7 @@ impl SeriesOptions {
             interval,
             starts_at_unix_timestamp,
             ends_at_unix_timestamp,
+            count,
             label,
         ): RubySeriesOptionsKwargs = args.required;
         let time_of_day = TimeOfDay::new_from_ruby_hash(time_of_day);
@@ -59,6 +63,7 @@ impl SeriesOptions {
             interval,
             starts_at_unix_timestamp,
             ends_at_unix_timestamp,
+            count,
             label,
         };
     }
@@ -73,6 +78,10 @@ impl SeriesOptions {
 
     pub fn interval(&self) -> i64 {
         return self.interval;
+    }
+
+    pub fn count(&self) -> Option<u64> {
+        return self.count;
     }
 
     pub fn label(&self) -> Option<String> {

--- a/ext/reprise/src/ruby_api/traits.rs
+++ b/ext/reprise/src/ruby_api/traits.rs
@@ -61,6 +61,14 @@ pub(crate) trait Recurrable: std::fmt::Debug {
         .unwrap();
     }
 
+    fn is_occurrence_count_reached(&self, occurrences: &Vec<Occurrence>) -> bool {
+        return if self.get_series_options().count.is_none() {
+            false
+        } else {
+            occurrences.len() as u64 >= self.get_series_options().count.unwrap()
+        }
+    }
+
     fn generate_occurrences(
         &self,
         starts_at: DateTime<Tz>,
@@ -82,7 +90,7 @@ pub(crate) trait Recurrable: std::fmt::Debug {
         let mut datetime_cursor =
             set_datetime_cursor_safely(starts_at, self.naive_starts_at_time());
 
-        while datetime_cursor < ends_at {
+        while datetime_cursor < ends_at && !self.is_occurrence_count_reached(&occurrences) {
             let occurrence_candidate_datetime_option =
                 self.next_occurrence_candidate(&datetime_cursor);
 

--- a/lib/reprise/schedule.rb
+++ b/lib/reprise/schedule.rb
@@ -85,6 +85,12 @@ module Reprise
     #     influences occurrence queries, and whether any added exclusions conflict with any of the schedule's
     #     occurrences.
 
+    # @!macro [new] count
+    #   @param count [Integer, nil] An optional count limit to apply to the occurrences
+    #     of a series; once the schedule has generated the requested number of occurrences,
+    #     it will halt further expansion of that specific series. The count takes precedence
+    #     over the optional +ends_at+ param.
+
     # @!macro [new] label
     #   @param label [String, nil] An optional label to apply to all of the occurrences
     #     that are generated from the series. See {Reprise::Core::Occurrence#label}.
@@ -93,6 +99,7 @@ module Reprise
     # @!macro duration_in_seconds
     # @!macro interval
     # @!macro recurring_series_start_and_end_times
+    # @!macro count
     # @!macro label
     # @return [void]
     def repeat_minutely(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
@@ -111,6 +118,7 @@ module Reprise
     # @!macro duration_in_seconds
     # @!macro interval
     # @!macro recurring_series_start_and_end_times
+    # @!macro count
     # @!macro label
     # @return [void]
     def repeat_hourly(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
@@ -129,6 +137,7 @@ module Reprise
     # @!macro duration_in_seconds
     # @!macro interval
     # @!macro recurring_series_start_and_end_times
+    # @!macro count
     # @!macro label
     # @return [void]
     def repeat_daily(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
@@ -148,6 +157,7 @@ module Reprise
     # @!macro duration_in_seconds
     # @!macro interval
     # @!macro recurring_series_start_and_end_times
+    # @!macro count
     # @!macro label
     # @return [void]
     # @example with a +time_of_day+ hash
@@ -173,6 +183,7 @@ module Reprise
     # @!macro duration_in_seconds
     # @!macro interval
     # @!macro recurring_series_start_and_end_times
+    # @!macro count
     # @!macro label
     # @return [void]
     # @example
@@ -196,6 +207,7 @@ module Reprise
     # @!macro duration_in_seconds
     # @!macro interval
     # @!macro recurring_series_start_and_end_times
+    # @!macro count
     # @!macro label
     # @return [void]
     def repeat_monthly_by_nth_weekday(weekday, nth_day, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
@@ -217,6 +229,7 @@ module Reprise
     # @!macro duration_in_seconds
     # @!macro interval
     # @!macro recurring_series_start_and_end_times
+    # @!macro count
     # @!macro label
     # @return [void]
     # @example

--- a/lib/reprise/schedule.rb
+++ b/lib/reprise/schedule.rb
@@ -95,13 +95,14 @@ module Reprise
     # @!macro recurring_series_start_and_end_times
     # @!macro label
     # @return [void]
-    def repeat_minutely(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)
+    def repeat_minutely(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
       internal_schedule.repeat_minutely(
         time_of_day: TimeOfDay.new(time_of_day || self.starts_at).to_h,
         duration_in_seconds:,
         interval:,
         starts_at_unix_timestamp: starts_at.presence&.to_i,
         ends_at_unix_timestamp: ends_at.presence&.to_i,
+        count:,
         label:
       )
     end
@@ -112,13 +113,14 @@ module Reprise
     # @!macro recurring_series_start_and_end_times
     # @!macro label
     # @return [void]
-    def repeat_hourly(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)
+    def repeat_hourly(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
       internal_schedule.repeat_hourly(
         time_of_day: TimeOfDay.new(time_of_day || self.starts_at).to_h,
         duration_in_seconds:,
         interval:,
         starts_at_unix_timestamp: starts_at.presence&.to_i,
         ends_at_unix_timestamp: ends_at.presence&.to_i,
+        count:,
         label:
       )
     end
@@ -129,13 +131,14 @@ module Reprise
     # @!macro recurring_series_start_and_end_times
     # @!macro label
     # @return [void]
-    def repeat_daily(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)
+    def repeat_daily(time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
       internal_schedule.repeat_daily(
         time_of_day: TimeOfDay.new(time_of_day || self.starts_at).to_h,
         duration_in_seconds:,
         interval:,
         starts_at_unix_timestamp: starts_at.presence&.to_i,
         ends_at_unix_timestamp: ends_at.presence&.to_i,
+        count:,
         label:
       )
     end
@@ -152,7 +155,7 @@ module Reprise
     # @example with a local time for +time_of_day+
     #   local_time = Time.current.in_time_zone(my_current_time_zone)
     #   schedule.repeat_weekly(:monday, time_of_day: local_time, duration_in_seconds: 30)
-    def repeat_weekly(weekday, time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)
+    def repeat_weekly(weekday, time_of_day: nil, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
       internal_schedule.repeat_weekly(
         weekday,
         time_of_day: TimeOfDay.new(time_of_day || self.starts_at).to_h,
@@ -160,6 +163,7 @@ module Reprise
         interval:,
         starts_at_unix_timestamp: starts_at.presence&.to_i,
         ends_at_unix_timestamp: ends_at.presence&.to_i,
+        count:,
         label:
       )
     end
@@ -173,7 +177,7 @@ module Reprise
     # @return [void]
     # @example
     #   schedule.repeat_monthly_by_day(15, time_of_day: { hour: 9 }, duration_in_seconds: 30)
-    def repeat_monthly_by_day(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)
+    def repeat_monthly_by_day(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
       internal_schedule.repeat_monthly_by_day(
         day_number,
         time_of_day: TimeOfDay.new(time_of_day || self.starts_at).to_h,
@@ -181,6 +185,7 @@ module Reprise
         interval:,
         starts_at_unix_timestamp: starts_at.presence&.to_i,
         ends_at_unix_timestamp: ends_at.presence&.to_i,
+        count:,
         label:
       )
     end
@@ -193,7 +198,7 @@ module Reprise
     # @!macro recurring_series_start_and_end_times
     # @!macro label
     # @return [void]
-    def repeat_monthly_by_nth_weekday(weekday, nth_day, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)
+    def repeat_monthly_by_nth_weekday(weekday, nth_day, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
       internal_schedule.repeat_monthly_by_nth_weekday(
         weekday,
         nth_day,
@@ -202,6 +207,7 @@ module Reprise
         interval:,
         starts_at_unix_timestamp: starts_at.presence&.to_i,
         ends_at_unix_timestamp: ends_at.presence&.to_i,
+        count:,
         label:
       )
     end
@@ -215,7 +221,7 @@ module Reprise
     # @return [void]
     # @example
     #   schedule.repeat_annually_by_day(200, duration_in_seconds: 30)
-    def repeat_annually_by_day(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, label: nil)
+    def repeat_annually_by_day(day_number, time_of_day:, duration_in_seconds:, interval: 1, starts_at: nil, ends_at: nil, count: nil, label: nil)
       internal_schedule.repeat_annually_by_day(
         day_number,
         time_of_day: TimeOfDay.new(time_of_day || self.starts_at).to_h,
@@ -223,6 +229,7 @@ module Reprise
         interval:,
         starts_at_unix_timestamp: starts_at.presence&.to_i,
         ends_at_unix_timestamp: ends_at.presence&.to_i,
+        count:,
         label:
       )
     end

--- a/spec/schedule/recurring_series/annually_by_day_spec.rb
+++ b/spec/schedule/recurring_series/annually_by_day_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe "#repeat_annually_by_day", aggregate_failures: true do
     end
   end
 
+  it_behaves_like "a series that supports an optional count argument" do
+    let(:series_options_hash) { series_options }
+    let(:occurrences) do
+      schedule.repeat_annually_by_day(200, **series_options_hash)
+      schedule.occurrences
+    end
+  end
+
   it "generates an array of annual occurrences" do
     schedule.repeat_annually_by_day(200, **series_options)
 

--- a/spec/schedule/recurring_series/daily_spec.rb
+++ b/spec/schedule/recurring_series/daily_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe "#repeat_daily", aggregate_failures: true do
     end
   end
 
+  it_behaves_like "a series that supports an optional count argument" do
+    let(:series_options_hash) { series_options }
+    let(:occurrences) do
+      schedule.repeat_daily(**series_options_hash)
+      schedule.occurrences
+    end
+  end
+
   it "generates an array of daily occurrences" do
     schedule.repeat_daily(**series_options(time_of_day: { hour: 1, minute: 2, second: 3 }))
 

--- a/spec/schedule/recurring_series/hourly_spec.rb
+++ b/spec/schedule/recurring_series/hourly_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe "#repeat_hourly", aggregate_failures: true do
     end
   end
 
+  it_behaves_like "a series that supports an optional count argument" do
+    let(:series_options_hash) { series_options(time_of_day: { hour: 1, minute: 2, second: 3 }) }
+    let(:occurrences) do
+      schedule.repeat_hourly(**series_options_hash)
+      schedule.occurrences
+    end
+  end
+
   it "generates an array of hourly occurrences" do
     schedule.repeat_hourly(**series_options(time_of_day: { hour: 1, minute: 2, second: 3 }))
 

--- a/spec/schedule/recurring_series/minutely_spec.rb
+++ b/spec/schedule/recurring_series/minutely_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe "#repeat_minutely", aggregate_failures: true do
     end
   end
 
+  it_behaves_like "a series that supports an optional count argument" do
+    let(:series_options_hash) { series_options(time_of_day: { hour: 1, minute: 2, second: 3 }) }
+    let(:occurrences) do
+      schedule.repeat_minutely(**series_options_hash)
+      schedule.occurrences
+    end
+  end
+
   it "generates an array of minutely occurrences" do
     schedule.repeat_minutely(**series_options, time_of_day: nil)
 

--- a/spec/schedule/recurring_series/monthly_by_day_spec.rb
+++ b/spec/schedule/recurring_series/monthly_by_day_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe "#repeat_monthly_by_day", aggregate_failures: true do
     end
   end
 
+  it_behaves_like "a series that supports an optional count argument" do
+    let(:series_options_hash) { series_options }
+    let(:occurrences) do
+      schedule.repeat_monthly_by_day(1, **series_options_hash)
+      schedule.occurrences
+    end
+  end
+
   it "generates an array of monthly occurrences" do
     schedule.repeat_monthly_by_day(1, **series_options)
 

--- a/spec/schedule/recurring_series/monthly_by_nth_weekday_spec.rb
+++ b/spec/schedule/recurring_series/monthly_by_nth_weekday_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe "#repeat_monthly_by_nth_weekday", aggregate_failures: true do
     end
   end
 
+  it_behaves_like "a series that supports an optional count argument" do
+    let(:series_options_hash) { series_options }
+    let(:occurrences) do
+      schedule.repeat_monthly_by_nth_weekday(:tuesday, 2, **series_options_hash)
+      schedule.occurrences
+    end
+  end
+
   it "generates an array of monthly occurrences with a fixed weekday" do
     schedule.repeat_monthly_by_nth_weekday(:tuesday, 2, time_of_day: { hour: 1, minute: 2, second: 3 }, duration_in_seconds: 300)
 

--- a/spec/schedule/recurring_series/weekly_spec.rb
+++ b/spec/schedule/recurring_series/weekly_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe "#repeat_weekly", aggregate_failures: true do
     end
   end
 
+  it_behaves_like "a series that supports an optional count argument" do
+    let(:series_options_hash) { series_options }
+    let(:occurrences) do
+      schedule.repeat_weekly(:monday, **series_options_hash)
+      schedule.occurrences
+    end
+  end
+
   it "generates an array of weekly occurrences" do
     schedule.repeat_weekly(:monday, duration_in_seconds: 30.minutes)
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -42,3 +42,14 @@ RSpec.shared_examples "a series that supports the duration_in_seconds argument" 
     ).to eq(true)
   end
 end
+
+# requires variables:
+# - series_options_hash
+# - occurrences
+RSpec.shared_examples "a series that supports an optional count argument" do
+  before { series_options_hash.merge!(count: 3) }
+
+  it "creates occurrences that are capped at the requested count" do
+    expect(occurrences.size).to eq(3)
+  end
+end


### PR DESCRIPTION
Adds support for an optional `count` kwarg that can be passed to all `repeat_*` series methods to constrain the number of occurrences to a given number.

This takes precedence over the also-optional `ends_at` series kwarg.

Example:

```ruby
may_26_2015_four_thirty_pm_in_rome = Time.parse("2015-05-26 10:30:45").in_time_zone("Rome")
# => Tue, 26 May 2015 16:30:45.000000000 CEST +02:00

schedule = Reprise::Schedule.new(
  starts_at: may_26_2015_four_thirty_pm_in_rome, 
  ends_at: may_26_2015_four_thirty_pm_in_rome + 1.year
)
#=> <Reprise::Schedule:0x000000011fdfb450

schedule.repeat_weekly(:sunday, duration_in_seconds: 15.minutes, count: 3)

schedule.occurrences.map(&:inspect)
# => ["<Reprise::Core::Occurrence starts_at=\"2015-05-31T14:30:45+00:00\" ends_at=\"2015-05-31T14:45:45+00:00\" label=\"nil\">",
# => "<Reprise::Core::Occurrence starts_at=\"2015-06-07T14:30:45+00:00\" ends_at=\"2015-06-07T14:45:45+00:00\" label=\"nil\">",
# => "<Reprise::Core::Occurrence starts_at=\"2015-06-14T14:30:45+00:00\" ends_at=\"2015-06-14T14:45:45+00:00\" label=\"nil\">"]
```